### PR TITLE
Remove rishigoutam.com from easylist-thailand

### DIFF
--- a/subscription/easylist-thailand.txt
+++ b/subscription/easylist-thailand.txt
@@ -950,7 +950,6 @@ thisisgamethailand.com,tigthai.com##.mod_banner_top
 ||restrainingorderlawyers.com
 ||reuseu.com
 ||rimpub.com
-||rishigoutam.com
 ||riyanfashion.com
 ||rootboundmarketing.com
 ||runaroundthailand.com


### PR DESCRIPTION
Removed rishigoutam.com from the easylist-thailand. This is my personal website and doesn't host ads or spam